### PR TITLE
Logstash cannot be run as root user, make ca.crt visible for others

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,8 +61,10 @@ services:
         fi;
         echo "Setting file permissions"
         chown -R root:root config/certs;
-        find . -type d -exec chmod 750 \{\} \;;
+        find . -type d -exec chmod 755 \{\} \;;
         find . -type f -exec chmod 640 \{\} \;;
+        echo "Set permission for public ca.crt viewable to others - logstash cannot be run as root and needs that"
+        chmod 644 config/certs/ca/ca.crt;
         echo "Waiting for Elasticsearch availability";
         until curl -s --cacert config/certs/ca/ca.crt https://es01:9200 | grep -q "missing authentication credentials"; do sleep 30; done;
         echo "Setting kibana_system password";
@@ -181,7 +183,7 @@ services:
       es01:
         condition: service_healthy
     image: docker.elastic.co/beats/filebeat:${STACK_VERSION}
-    user: root
+    user: logstash
     volumes:
       - certs:/usr/share/filebeat/certs
       - filebeatdata01:/usr/share/filebeat/data

--- a/logstash.conf
+++ b/logstash.conf
@@ -22,6 +22,6 @@ output {
     hosts=> "${ELASTIC_HOSTS}"
     user=> "${ELASTIC_USER}"
     password=> "${ELASTIC_PASSWORD}"
-    cacert=> "certs/ca/ca.crt"
+    ssl_certificate_authorities => "/usr/share/logstash/certs/ca/ca.crt"
   }
 }


### PR DESCRIPTION
Running this docker-compose.yml, makes logstash exit due to:
```
[FATAL] 2025-07-05 21:46:05.890 [main] runner - An unexpected error occurred! {:error=>#<RuntimeError: Logstash cannot be run as superuser.>
```
(e.g. https://discuss.elastic.co/t/new-logstash-installation-is-not-working/379824/7)
Default user in logstash conatiner is logstash, so to enable him to see public CA cert, make ca.crt visible for others (644).
Moreover cacert in logstash.conf in elasticsearch output is depracated.